### PR TITLE
修复验证包头的一个bug

### DIFF
--- a/socketclient/src/main/java/com/vilyever/socketclient/helper/SocketInputReader.java
+++ b/socketclient/src/main/java/com/vilyever/socketclient/helper/SocketInputReader.java
@@ -101,7 +101,7 @@ public class SocketInputReader extends Reader {
 
                 while (-1 != (c = this.inputStream.read())) {
                     list.add((byte) c);
-                    if (c == data[matchIndex]) {
+                    if (c == (0xff & data[matchIndex])) {
                         matchIndex++;
                     }
                     else {


### PR DESCRIPTION
byte有符号，inputStream.read()读出来的整型为正值，在判断是否相等时需要把byte转为无符号
